### PR TITLE
Implement newproject generation feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 cli.py
 m
 notebooks/*png
-main.py
+/main.py
 d
 
 # Byte-compiled / optimized / DLL files

--- a/zero_aidev_framework/cli.py
+++ b/zero_aidev_framework/cli.py
@@ -1,6 +1,9 @@
 import argparse
+from pathlib import Path
+
 from zero_aidev_framework import docs_tools
 from zero_aidev_framework.docs_tools import new_doc as create_new_doc
+from zero_aidev_framework.main import duplicate_project
 
 
 def main(argv=None):
@@ -39,9 +42,9 @@ def main(argv=None):
 
     if args.command == "newproject":
         if args.new:
-            # new project
-            # import code from zero_aidev_framework.main to duplicate this
-            0
+            if not args.filepath or not args.project_name:
+                parser.error("--filepath and --project-name required with --new")
+            duplicate_project(Path(args.filepath), args.project_name)
     elif args.command == "dev":
         if args.update_toc:
             docs_tools.update_toc()

--- a/zero_aidev_framework/main.py
+++ b/zero_aidev_framework/main.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+
+
+def _copytree(src: Path, dst: Path) -> None:
+    """Copy ``src`` to ``dst`` ignoring git metadata."""
+    ignore = shutil.ignore_patterns('.git', '__pycache__', '*.pyc', '*.pyo')
+    shutil.copytree(src, dst, ignore=ignore)
+
+
+def _replace_in_file(path: Path, old: str, new: str) -> None:
+    try:
+        text = path.read_text(encoding='utf-8')
+    except UnicodeDecodeError:
+        return
+    updated = text.replace(old, new)
+    hy_old = old.replace('_', '-')
+    hy_new = new.replace('_', '-')
+    updated = updated.replace(hy_old, hy_new)
+    if updated != text:
+        path.write_text(updated, encoding='utf-8')
+
+
+def duplicate_project(target_dir: Path, package_name: str) -> Path:
+    """Duplicate this project to ``target_dir`` with a new package name.
+
+    Parameters
+    ----------
+    target_dir:
+        Destination directory for the new project.
+    package_name:
+        Desired package/module name for the new project.
+    """
+    src_root = Path(__file__).resolve().parents[1]
+    target_dir = Path(target_dir)
+    if target_dir.exists():
+        raise FileExistsError(target_dir)
+
+    _copytree(src_root, target_dir)
+
+    old_pkg = target_dir / 'zero_aidev_framework'
+    new_pkg = target_dir / package_name
+    old_pkg.rename(new_pkg)
+
+    for path in target_dir.rglob('*'):
+        if path.is_file():
+            if path.suffix in {'.py', '.toml', '.md'}:
+                _replace_in_file(path, 'zero_aidev_framework', package_name)
+
+    cli_link = target_dir / 'cli.py'
+    if cli_link.exists():
+        cli_link.unlink()
+    cli_link.symlink_to(Path(package_name) / 'cli.py')
+
+    return target_dir
+
+
+__all__ = ['duplicate_project']


### PR DESCRIPTION
## Summary
- create `duplicate_project` in `main.py` to copy and rename the project
- expose the functionality through the CLI
- allow `zero_aidev_framework/main.py` to be tracked by git

## Testing
- `python -m py_compile zero_aidev_framework/cli.py zero_aidev_framework/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd75360b88323a7c887bd32305346